### PR TITLE
Changed graveyard to vectors

### DIFF
--- a/lib/src/board/mod.rs
+++ b/lib/src/board/mod.rs
@@ -9,11 +9,10 @@ mod test_get_moves;
 
 use crate::pieces::{Kind, Piece};
 use crate::*;
-use std::collections::HashMap;
 
 pub struct Board {
     pub current: [Option<Piece>; 64],
-    pub graveyard: HashMap<Color, Vec<Piece>>,
+    pub graveyard: [Vec<Piece>; 2],
     pub height: std::ops::RangeInclusive<i8>,
     pub width: std::ops::RangeInclusive<i8>,
 }
@@ -54,9 +53,7 @@ impl Board {
 
         Board {
             current: starting_board,
-            graveyard: vec![(Color::White, vec![]), (Color::Black, vec![])]
-                .into_iter()
-                .collect(),
+            graveyard: [Vec::new(), Vec::new()],
             height: (1..=8),
             width: (1..=8),
         }
@@ -147,8 +144,7 @@ impl Board {
             if target_piece.color == source_piece.color {
                 return false;
             } else {
-                let graveyard = self.graveyard.entry(target_piece.color).or_default();
-                graveyard.push(target_piece);
+                &mut self.add_to_graveyard(target_piece);
             }
         }
 
@@ -159,6 +155,10 @@ impl Board {
         self.current[source_index] = None;
 
         true
+    }
+
+    fn add_to_graveyard(&mut self, piece: Piece) {
+        self.graveyard[piece.color.get_index()].push(piece);
     }
 
     pub fn get_allowed_moves(&mut self, source: &Point) -> Option<Vec<Point>> {

--- a/lib/src/board/test_move_piece.rs
+++ b/lib/src/board/test_move_piece.rs
@@ -1,6 +1,5 @@
 use super::tests::create_test_board;
 use super::{Color, Kind, Piece, Point};
-use std::collections::HashMap;
 
 #[test]
 fn test_move_to_empty_and_sets_has_moved() {
@@ -67,15 +66,11 @@ fn test_move_to_occupied_by_other_color() {
         })
     );
 
-    assert!(board
-        .graveyard
-        .get(&Color::Black)
-        .unwrap()
-        .contains(&Piece {
-            color: Color::Black,
-            kind: Kind::Pawn,
-            has_moved: false,
-        }));
+    assert!(board.graveyard[1].contains(&Piece {
+        color: Color::Black,
+        kind: Kind::Pawn,
+        has_moved: false,
+    }));
 }
 
 #[test]
@@ -85,12 +80,12 @@ fn test_move_to_occupied_by_other_color_empty_graveyard() {
         (Point(2, 1), Piece::new(Color::Black, Kind::Pawn)),
     ]);
 
-    board.graveyard = HashMap::new();
+    board.graveyard = [vec![], vec![]];
 
     board.move_piece(Point(1, 1), Point(2, 1));
 
-    assert!(board.graveyard.contains_key(&Color::Black));
-    assert!(!board.graveyard.contains_key(&Color::White));
+    assert_eq!(board.graveyard[0].len(), 0);
+    assert_eq!(board.graveyard[1].len(), 1);
 }
 
 #[test]

--- a/lib/src/board/tests.rs
+++ b/lib/src/board/tests.rs
@@ -7,9 +7,7 @@ pub fn create_test_board(positions: Vec<(Point, Piece)>) -> Board {
     }
     Board {
         current,
-        graveyard: vec![(Color::White, vec![]), (Color::Black, vec![])]
-            .into_iter()
-            .collect(),
+        graveyard: [vec![], vec![]],
         height: (1..=8),
         width: (1..=8),
     }
@@ -17,7 +15,7 @@ pub fn create_test_board(positions: Vec<(Point, Piece)>) -> Board {
 
 #[test]
 fn test_detect_check() {
-    let mut board = create_test_board(vec![
+    let board = create_test_board(vec![
         (Point(4, 4), Piece::new(Color::White, Kind::King)),
         (Point(3, 4), Piece::new(Color::White, Kind::Rook)),
         (Point(2, 4), Piece::new(Color::Black, Kind::Rook)),
@@ -38,7 +36,7 @@ fn test_detect_check() {
 
 #[test]
 fn test_find_king() {
-    let mut board = create_test_board(vec![
+    let board = create_test_board(vec![
         (Point(3, 8), Piece::new(Color::White, Kind::King)),
         (Point(8, 3), Piece::new(Color::Black, Kind::King)),
     ]);

--- a/lib/src/game/tests.rs
+++ b/lib/src/game/tests.rs
@@ -9,9 +9,7 @@ pub fn create_test_board(positions: Vec<(Point, Piece)>) -> Board {
 
     Board {
         current,
-        graveyard: vec![(Color::White, vec![]), (Color::Black, vec![])]
-            .into_iter()
-            .collect(),
+        graveyard: [vec![], vec![]],
         height: (1..=8),
         width: (1..=8),
     }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -74,6 +74,12 @@ impl Color {
             Color::Black => Color::White,
         }
     }
+    fn get_index(&self) -> usize {
+        match self {
+            Color::White => 0,
+            Color::Black => 1,
+        }
+    }
 }
 
 #[derive(Clone, PartialEq, Debug)]


### PR DESCRIPTION
fixes #7 
-Graveyard changed to array of two vectors.
-Color::get_index() added to access player specific graveyards.
